### PR TITLE
Enabled permissive kernel

### DIFF
--- a/security/selinux/selinuxfs.c
+++ b/security/selinux/selinuxfs.c
@@ -160,7 +160,7 @@ static ssize_t sel_write_enforce(struct file *file, const char __user *buf,
 // [ SEC_SELINUX_PORTING_COMMON
 #ifdef CONFIG_ALWAYS_ENFORCE
      // If build is user build and enforce option is set, selinux is always enforcing
-     new_value = 1;
+     new_value = 0;
      length = avc_has_perm(current_sid(), SECINITSID_SECURITY,
                   SECCLASS_SECURITY, SECURITY__SETENFORCE,
                   NULL);


### PR DESCRIPTION
...
new_value = 0;
     length = avc_has_perm(current_sid(), SECINITSID_SECURITY,
                  SECCLASS_SECURITY, SECURITY__SETENFORCE,
                  NULL);
     audit_log(current->audit_context, GFP_KERNEL, AUDIT_MAC_STATUS,
         "config_always_enforce - true; enforcing=%d old_enforcing=%d auid=%u ses=%u",
         new_value, selinux_enforcing,
         from_kuid(&init_user_ns, audit_get_loginuid(current)),
         audit_get_sessionid(current));
#if !defined(CONFIG_RKP_KDP)
     selinux_enforcing = new_value;
...